### PR TITLE
Update README to reflect code envvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ Example configuration for running with Podman:
         "run",
         "-i",
         "--rm",
-        "-e", "SLACK_MCP_XOXC_TOKEN",
-        "-e", "SLACK_MCP_XOXD_TOKEN",
+        "-e", "SLACK_XOXC_TOKEN",
+        "-e", "SLACK_XOXD_TOKEN",
         "-e", "MCP_TRANSPORT",
         "-e", "LOGS_CHANNEL_ID",
         "quay.io/redhat-ai-tools/slack-mcp"
       ],
       "env": {
-        "SLACK_MCP_XOXC_TOKEN": "xoxc-...",
-        "SLACK_MCP_XOXD_TOKEN": "xoxd-...",
+        "SLACK_XOXC_TOKEN": "xoxc-...",
+        "SLACK_XOXD_TOKEN": "xoxd-...",
         "MCP_TRANSPORT": "stdio",
         "LOGS_CHANNEL_ID": "C7000000",
       }


### PR DESCRIPTION
It seems the README and code may have gotten out of sync.

The code:
```
    if MCP_TRANSPORT == "stdio":
        xoxc_token = os.environ["SLACK_XOXC_TOKEN"]
        xoxd_token = os.environ["SLACK_XOXD_TOKEN"]
```
references `SLACK_XOXC_TOKEN` and `SLACK_XOXD_TOKEN` but the README used alternate formats of the environment variables.

This PR updates the README to match the code.